### PR TITLE
Add spec for 1.63.0 CocoaPods distribution

### DIFF
--- a/boost-for-react-native.podspec
+++ b/boost-for-react-native.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |spec|
+  spec.name = 'boost-for-react-native'
+  spec.version = '1.63.0'
+  spec.license = { :type => 'Boost Software License', :file => "LICENSE_1_0.txt" }
+  spec.homepage = 'http://www.boost.org'
+  spec.summary = 'Boost provides free peer-reviewed portable C++ source libraries.'
+  spec.authors = 'Rene Rivera'
+  spec.source = { :git => 'https://github.com/react-native-community/boost-for-react-native.git',
+                  :tag => 'v1.63.0-0' }
+
+  # Pinning to the same version as React.podspec.
+  spec.platforms = { :ios => '8.0', :tvos => '9.2' }
+  spec.requires_arc = false
+
+  spec.module_name = 'boost'
+  spec.header_dir = 'boost'
+  spec.preserve_path = 'boost'
+end


### PR DESCRIPTION
Fixes #3 

Since React Native uses a header-only distribution of Boost, it's _much_ more efficient to just preserve the `boost/` directory structure and use this repo directly. Besides avoiding binary downloads, this should avoid a lot of unnecessary CocoaPods work on install.

This is already available as the CocoaPod `boost-for-react-native`. Let me know whose emails I should add as maintainers so it can be updated in the future.
  