### PR TITLE
fix parameter comment

### DIFF
--- a/boost/range/iterator_range_core.hpp
+++ b/boost/range/iterator_range_core.hpp
@@ -864,7 +864,7 @@ public:
             Construct a new sequence of the specified type from the elements
             in the given range
 
-            \param Range An input range
+            \param r An input range
             \return New sequence
         */
         template< typename SeqT, typename Range >


### PR DESCRIPTION
I found a warning in Xcode:

![image](https://user-images.githubusercontent.com/10719495/39698511-19b327c2-5230-11e8-97fd-cc4d2bc3295a.png)

I changed the param comment then the warning has gone:

![image](https://user-images.githubusercontent.com/10719495/39698557-4647f1c8-5230-11e8-920d-98ce136d33b3.png)


Thanks.