### PR TITLE
Silence -Wdocumentation warnings

### DIFF
--- a/boost-for-react-native.podspec
+++ b/boost-for-react-native.podspec
@@ -7,6 +7,7 @@ Pod::Spec.new do |spec|
   spec.authors = 'Rene Rivera'
   spec.source = { :git => 'https://github.com/react-native-community/boost-for-react-native.git',
                   :tag => 'v1.63.0-0' }
+  spec.compiler_flags = '-Wno-documentation'
 
   # Pinning to the same version as React.podspec.
   spec.platforms = { :ios => '8.0', :tvos => '9.2' }


### PR DESCRIPTION
Silence warnings:
- "warning: parameter 'Comp' not found in the function declaration [-Wdocumentation]"
- "warning: parameter 'Input' not found in the function declaration [-Wdocumentation]"

When compiling a React Native project using CocoaPods, you currently see a lot of warnings for 3rd party libraries that don't directly affect you and are not actionable by the library consumer. These warnings should go away.