### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Boost for React Native
 
-This is a copy of [Boost](http://www.boost.org/) that is used to build React Native (Android) from source. It includes just the Boost source code (without the docs, for example) so that downloading and extracting the files doesn't take too long.
+This is a copy of [Boost](http://www.boost.org/) that is used to build React Native from source. It includes just the Boost source code (without the docs, for example) so that downloading and extracting the files doesn't take too long.
 
 You probably don't want to directly use this repository. Its sole purpose is to distribute the Boost code for building React Native.
 


### PR DESCRIPTION
# Summary
Boost is used to build iOS version of React Native too, fix README to reflect that. 
Fixes https://github.com/react-native-community/boost-for-react-native/issues/8