### PR TITLE
update iOS platform version to match RN

### DIFF
--- a/boost-for-react-native.podspec
+++ b/boost-for-react-native.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
                   :tag => 'v1.63.0-0' }
 
   # Pinning to the same version as React.podspec.
-  spec.platforms = { :ios => '8.0', :tvos => '9.2' }
+  spec.platforms = { :ios => '10.0', :tvos => '9.2' }
   spec.requires_arc = false
 
   spec.module_name = 'boost'


### PR DESCRIPTION
This PR bumps the iOS platform version in `podspec` to match the version currently used in the React Native:
* https://github.com/facebook/react-native/commit/674b591809cd1275b5f1c4d203c2f0ec52303396#diff-c272637916995f80d9a1d114cf3943a365941f84afea1fc2abf7b880d1f62a64

I have not bumped the `tvOS` version because  since last release using the out-of-tree platform [`react-native-tvos`](https://github.com/react-native-tvos/react-native-tvos) is recommended and `tvOS` platform has been removed from the [`React.podspec`](https://github.com/facebook/react-native/blob/master/React.podspec#L39). CC @dlowder-salesforce 

This change also fixes the warning during the build:
<img width="1354" alt="Screenshot 2020-11-19 141536" src="https://user-images.githubusercontent.com/719641/99671011-b74ed500-2a71-11eb-98fd-48d1de5f9b8d.png">
