### PR TITLE
Change the target platforms to iOS 11.0 and tvOS 11.0 to match RN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+
+# Unreleased
+
+## Breaking changes
+
+## New features
+
+## Bug fixes
+
+
+# 1.63.0-1
+
+## Breaking changes
+
+Changed the target platform versions to iOS 11.0 and tvOS 11.0, matching the versions currently targeted by React Native.
+
+## Bug fixes
+
+Suppress warnings (`-Wno-documentation`) for vendored code. Consumers of this library aren't responsible for them.
+
+
+# 1.63.0-0
+
+## New features
+
+Upgraded to Boost v1.63.0

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This is a copy of [Boost](http://www.boost.org/) that is used to build React Nat
 
 You probably don't want to directly use this repository. Its sole purpose is to distribute the Boost code for building React Native.
 
+This library does not necessarily follow semver. It follows Boost's versioning plus a number in thepprerelease identifier position. React Native declares the exact version of this library it depends on instead of using semver ranges.
+
 ## Upgrading Boost
 
 First, download a new version of Boost, e.g.: http://www.boost.org/users/history/version_1_63_0.html

--- a/boost-for-react-native.podspec
+++ b/boost-for-react-native.podspec
@@ -1,16 +1,15 @@
 Pod::Spec.new do |spec|
   spec.name = 'boost-for-react-native'
-  spec.version = '1.63.0'
+  spec.version = '1.63.0-1'
   spec.license = { :type => 'Boost Software License', :file => "LICENSE_1_0.txt" }
   spec.homepage = 'http://www.boost.org'
   spec.summary = 'Boost provides free peer-reviewed portable C++ source libraries.'
   spec.authors = 'Rene Rivera'
   spec.source = { :git => 'https://github.com/react-native-community/boost-for-react-native.git',
-                  :tag => 'v1.63.0-0' }
-  spec.compiler_flags = '-Wno-documentation'
+                  :tag => 'v1.63.0-1' }
 
   # Pinning to the same version as React.podspec.
-  spec.platforms = { :ios => '10.0', :tvos => '10.0' }
+  spec.platforms = { :ios => '11.0', :tvos => '11.0' }
   spec.requires_arc = false
 
   spec.module_name = 'boost'

--- a/boost-for-react-native.podspec
+++ b/boost-for-react-native.podspec
@@ -7,6 +7,7 @@ Pod::Spec.new do |spec|
   spec.authors = 'Rene Rivera'
   spec.source = { :git => 'https://github.com/react-native-community/boost-for-react-native.git',
                   :tag => 'v1.63.0-1' }
+  spec.compiler_flags = '-Wno-documentation'
 
   # Pinning to the same version as React.podspec.
   spec.platforms = { :ios => '11.0', :tvos => '11.0' }


### PR DESCRIPTION
React Native's podspec currently targets iOS 11.0 and up. Additionally, the current version of Xcode warns because this Boost podspec targets 8.0, which Xcode no longer supports. This commit changes the target version to 11.0, since 9 and 10 are unsupported by React Native anyway.

This commit also adds a changelog and changes the podspec version to 1.63.0-1. React Native pins its version of the boost-for-react-native dependency and the readme says this library's sole purpose is for React Native.

It is technically a breaking change to constrain the target platform and an earlier version of this PR bumped the CocoaPod version to 2.0.0, but decided not to take that path given the scope of this change and the fact that this library is not intended to be used outside of React Native.

Additionally, 1.63.0-1 precedes 1.63.0 according to semver, so any projects depending on `~> '1.63.0'` won't pick up this version. But to reiterate, this library's sole purpose is to be used by React Native, and the readme now explicitly says this library does not follow semver.