### PR TITLE
Fix this

### DIFF
--- a/boost-for-react-native.podspec
+++ b/boost-for-react-native.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |spec|
   spec.name = 'boost-for-react-native'
-  spec.version = '1.63.0-1'
+  spec.version = '1.63.0'
   spec.license = { :type => 'Boost Software License', :file => "LICENSE_1_0.txt" }
   spec.homepage = 'http://www.boost.org'
   spec.summary = 'Boost provides free peer-reviewed portable C++ source libraries.'
   spec.authors = 'Rene Rivera'
   spec.source = { :git => 'https://github.com/react-native-community/boost-for-react-native.git',
-                  :tag => 'v1.63.0-1' }
+                  :tag => 'v1.63.0' }
 
   # Pinning to the same version as React.podspec.
   spec.platforms = { :ios => '11.0', :tvos => '11.0' }


### PR DESCRIPTION
[!] CocoaPods could not find compatible versions for pod "boost-for-react-native"